### PR TITLE
Call pam_open_session only after VPN fully up

### DIFF
--- a/programs/pluto/ikev1_quick.c
+++ b/programs/pluto/ikev1_quick.c
@@ -83,6 +83,8 @@
 #include "alg_info.h"
 #include "ip_address.h"
 
+#include "pam_conv.h" /* needs struct xauth */
+
 #include <blapit.h>
 
 /* accept_PFS_KE
@@ -1986,6 +1988,19 @@ stf_status quick_inI2(struct state *st, struct msg_digest *md)
 			return STF_FAIL;
 		}
 	}
+
+	/*
+	 * Tell the xauth thread it's finally time to start the session for
+	 * e.g., billing. We need to find the phase1 state, though, since
+	 * that's where the xauth is.
+	*/
+    struct state *p1st = state_with_serialno(st->st_clonedfrom);
+    if (!p1st || !p1st->st_xauth) {
+			delete_ipsec_sa(st);
+			return STF_FAIL;
+
+	}
+	atomic_flag_clear(&p1st->st_xauth->vpn_still_starting);
 
 	return STF_OK;
 }

--- a/programs/pluto/pam_conv.h
+++ b/programs/pluto/pam_conv.h
@@ -19,6 +19,7 @@
 
 //#include "xauth.h"
 #include "constants.h"
+#include <stdatomic.h>
 struct state;
 
 typedef void xauth_callback_t(
@@ -30,11 +31,12 @@ struct app_pam_data { const char* password; };
 
 enum pam_state_t {
     PAM_AUTH = 0,
-    PAM_SESSION_START = 1,
-    PAM_SESSION_END = 2,
-    PAM_TERM = 3,
-    PAM_STATE_UNKNOWN = 4,
-    PAM_DO_NOTHING = 5
+    PAM_CALLBACK = 1,
+    PAM_SESSION_START = 2,
+    PAM_SESSION_END = 3,
+    PAM_TERM = 4,
+    PAM_STATE_UNKNOWN = 5,
+    PAM_DO_NOTHING = 6
 
 };
 
@@ -75,6 +77,7 @@ struct xauth {
 	xauth_callback_t *callback;
 	bool abort;
 	pid_t child;
+	atomic_flag vpn_still_starting;
 };
 
 extern bool do_pam_authentication(struct pam_thread_arg *arg);

--- a/programs/pluto/xauth.c
+++ b/programs/pluto/xauth.c
@@ -52,6 +52,7 @@ void xauth_start_pam_thread(struct state *st,
 
 	xauth->callback = callback;
 	xauth->serialno = serialno;
+	atomic_flag_test_and_set(&xauth->vpn_still_starting);
 	gettimeofday(&xauth->tv0, NULL);
 
 	/* fill in pam_thread_arg with info for the child process */


### PR DESCRIPTION
This moves the pam_open_session call to after the IPSec SA/Quick Mode/Phase 2 is complete. It addresses internal ticket [TABLET-1380].