### PR TITLE
Recover from loss of modecfg ip request reply

### DIFF
--- a/include/pluto_constants.h
+++ b/include/pluto_constants.h
@@ -267,7 +267,7 @@ typedef enum {
 
 /* Misc. stuff */
 
-#define MAXIMUM_v1_ACCEPTED_DUPLICATES        2
+#define MAXIMUM_v1_ACCEPTED_DUPLICATES        4
 /*
  * maximum retransmits per exchange, for IKEv1 (initiator and responder),
  * IKEv2 initiator

--- a/programs/pluto/ikev1.c
+++ b/programs/pluto/ikev1.c
@@ -543,7 +543,7 @@ static const struct state_v1_microcode v1_state_microcode_table[] = {
 	{ STATE_MODE_CFG_R0, STATE_MODE_CFG_R1,
 	  SMF_ALL_AUTH | SMF_ENCRYPTED | SMF_REPLY,
 	  P(MCFG_ATTR) | P(HASH), P(VID),
-	  EVENT_SA_REPLACE, modecfg_inR0 },
+	  EVENT_v1_RETRANSMIT, modecfg_inR0 },
 
 	{ STATE_MODE_CFG_R1, STATE_MODE_CFG_R2,
 	  SMF_ALL_AUTH | SMF_ENCRYPTED | SMF_RETRANSMIT_ON_DUPLICATE,

--- a/programs/pluto/ikev1.c
+++ b/programs/pluto/ikev1.c
@@ -546,7 +546,7 @@ static const struct state_v1_microcode v1_state_microcode_table[] = {
 	  EVENT_SA_REPLACE, modecfg_inR0 },
 
 	{ STATE_MODE_CFG_R1, STATE_MODE_CFG_R2,
-	  SMF_ALL_AUTH | SMF_ENCRYPTED,
+	  SMF_ALL_AUTH | SMF_ENCRYPTED | SMF_RETRANSMIT_ON_DUPLICATE,
 	  P(MCFG_ATTR) | P(HASH), P(VID),
 	  EVENT_SA_REPLACE, modecfg_inR1 },
 
@@ -1434,6 +1434,10 @@ void process_v1_packet(struct msg_digest **mdp)
 					    enum_name(&state_names,
 						      st->st_state
 						      )));
+			} else if (st->st_connection->spd.this.modecfg_server
+				   && STATE_MODE_CFG_R1 == st->st_state) {
+				from_state = STATE_MODE_CFG_R1;
+				plog("already in STATE_MODE_CFG_R1, probably a retransmit");
 			} else if (st->st_connection->spd.this.modecfg_client
 				   &&
 				   IS_PHASE1(st->st_state)) {

--- a/programs/pluto/ikev2_spdb_struct.c
+++ b/programs/pluto/ikev2_spdb_struct.c
@@ -1117,7 +1117,7 @@ stf_status ikev2_process_sa_payload(const char *what,
 	 *
 	 * Must be freed by this function.
 	 */
-	stf_status status;
+	stf_status status = STF_FAIL;
 	LSWBUF(remote_print_buf) {
 		int matching_local_propnum = ikev2_process_proposals(sa_payload,
 								     expect_ike, expect_spi,


### PR DESCRIPTION
    Previously, if the reply packet to an IP request (MODECFG_R0/R1) were
    lost, the modecfg client (requestor) would retransmit it, but then the
    modecfg server would discard it, because it wasn't the expected packet.
    The connection thus hung until it eventually timed out and terminated.
    
    Now, instead, retransmit the reply upon receiving a duplicate request.
    This allows the connection to succeed.
    
    Also up the maximum number of times we'll retransmit in response to a
    duplicate packet from 2 to 4. That allows for a longer blip and the
    connection to still succeed.
    
    Fixes internal issue [TABLET-1418]