### PR TITLE
Tell updown script if DPD cleared connection

### DIFF
--- a/programs/pluto/connections.c
+++ b/programs/pluto/connections.c
@@ -2003,6 +2003,7 @@ struct connection *instantiate(struct connection *c, const ip_address *him,
 	d->newest_isakmp_sa = SOS_NOBODY;
 	d->newest_ipsec_sa = SOS_NOBODY;
 	d->spd.eroute_owner = SOS_NOBODY;
+	d->dpd_killed = FALSE;
 
 	/* reset log file info */
 	d->log_file_name = NULL;
@@ -4201,6 +4202,7 @@ void liveness_action(struct connection *c, enum ike_version ike_version)
 	case DPD_ACTION_CLEAR:
 		libreswan_log("%s action - clearing connection kind %s", ikev,
 				enum_name(&connection_kind_names, c->kind));
+		c->dpd_killed = TRUE;
 		liveness_clear_connection(c, ikev);
 		break;
 

--- a/programs/pluto/connections.h
+++ b/programs/pluto/connections.h
@@ -281,6 +281,7 @@ struct connection {
 	deltatime_t dpd_delay;		/* time between checks */
 	deltatime_t dpd_timeout;	/* time after which we are dead */
 	enum dpd_action dpd_action;	/* what to do when we die */
+	bool dpd_killed;            /* dpd caused connection to end */
 
 	bool nat_keepalive;		/* Send NAT-T Keep-Alives if we are behind NAT */
 	bool initial_contact;		/* Send INITIAL_CONTACT (RFC-2407) payload? */

--- a/programs/pluto/kernel.c
+++ b/programs/pluto/kernel.c
@@ -493,6 +493,8 @@ static void jam_common_shell_out(jambuf_t *buf, const struct connection *c,
 
 	jam(buf, "PLUTO_STACK='%s' ", kernel_ops->kern_name);
 
+	jam(buf, "PLUTO_DPD_CLEAR=%i ", (int)c->dpd_killed);
+
 	if (c->metric != 0) {
 		jam(buf, "PLUTO_METRIC=%d ", c->metric);
 	}


### PR DESCRIPTION
We'd like to know if the connection went down because of loss of network
connectivity (DPD) or some other reason. First step, export that data
out of Libreswan.

[TABLET-2117]