### PR TITLE
Re-implement the PLUTO_DPD_CLEAR env for 4.12

### DIFF
--- a/programs/pluto/connections.c
+++ b/programs/pluto/connections.c
@@ -2738,6 +2738,7 @@ struct connection *instantiate(struct connection *c,
 
 	d->newest_ike_sa = SOS_NOBODY;
 	d->newest_ipsec_sa = SOS_NOBODY;
+	d->dpd_killed = false;
 
 
 	/* reset log file info */

--- a/programs/pluto/connections.h
+++ b/programs/pluto/connections.h
@@ -503,6 +503,8 @@ struct connection {
 		newest_ike_sa,
 		newest_ipsec_sa;
 
+	bool dpd_killed;
+
 	lmod_t extra_debugging;
 
 	/* if multiple policies, next one to apply */

--- a/programs/pluto/ikev1_dpd.c
+++ b/programs/pluto/ikev1_dpd.c
@@ -69,6 +69,7 @@ static void dpd_clear_connection(struct connection *c)
 	 * Note that delete_states_by_connection changes c->kind but we need
 	 * to remember what it was to know if we still need to unroute after delete
 	 */
+	c->dpd_killed = true;
 	flush_pending_by_connection(c); /* remove any partial negotiations that are failing */
 	delete_v1_states_by_connection_family(&c);	/* may change c to NULL */
 	/*

--- a/programs/pluto/kernel.c
+++ b/programs/pluto/kernel.c
@@ -603,6 +603,8 @@ bool fmt_common_shell_out(char *buf,
 
 	JDstr("PLUTO_STACK", kernel_ops->updown_name);
 
+	JDuint("PLUTO_DPD_CLEAR", (unsigned int)c->dpd_killed);
+
 	if (c->metric != 0) {
 		jam(&jb, "PLUTO_METRIC=%d ", c->metric);
 	}


### PR DESCRIPTION
3.32 had a patch (960533723fb6c7666636251679ddf22195a2e1b2) to add a PLUTO_DPD_CLEAR environment variable when calling the updown script; that got lost when porting patches to 4.12. Re-add it.

[TABLET-10198]